### PR TITLE
chore: remove ram disk from $GITHUB_WORKSPACE

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,13 +58,3 @@ runs:
         aim_ll -a -s "20%" -m "$RUNNER_TEMP" -p "/fs:ntfs /q /y"
         cp -r "$RUNNER_TEMP"_tmp/. "$RUNNER_TEMP"
         rm -rf "$RUNNER_TEMP"_tmp
-
-        # RAM disk for the repository
-        rm -rf "$GITHUB_WORKSPACE"/*
-        # Use exfat instead of ntfs because ntfs creates an unremovable
-        # "System Volume Information" directory that makes actions/checkout fail.
-        # exfat is empty on creation
-        aim_ll -a -s "20%" -m "$GITHUB_WORKSPACE" -p "/fs:nfts /q /y"
-        # node's fs.promises.readdir used by actions/checkout fails if the
-        # directory is empty.
-        touch "$GITHUB_WORKSPACE"/dummy.txt

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
         # Use exfat instead of ntfs because ntfs creates an unremovable
         # "System Volume Information" directory that makes actions/checkout fail.
         # exfat is empty on creation
-        aim_ll -a -s "20%" -m "$GITHUB_WORKSPACE" -p "/fs:exfat /q /y"
+        aim_ll -a -s "20%" -m "$GITHUB_WORKSPACE" -p "/fs:nfts /q /y"
         # node's fs.promises.readdir used by actions/checkout fails if the
         # directory is empty.
         touch "$GITHUB_WORKSPACE"/dummy.txt


### PR DESCRIPTION
Previously, `$GITHUB_WORKSPACE` was backed by an exFAT filesystem due to an issue with `actions/checkout` (described in the file edited in this PR) that prevented the use of NTFS. However, exFAT is incompatible with [mtimehash](https://github.com/slsyy/mtimehash), which we need to ensure test cache hits. The problem is that exFAT only supports file modification times from 1980 onward, while mtimehash can generate values earlier than that. By default, `$GITHUB_WORKSPACE` is backed by NTFS, which does not have this limitation.
